### PR TITLE
WIP pushing to quay

### DIFF
--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -92,38 +92,3 @@ jobs:
 #     https://github.com/marketplace/actions/debugging-with-tmate
 #    - name: Setup tmate session
 #      uses: mxschmitt/action-tmate@v1
-
-  # Optionally publish container images, guarded by the GitHub secret
-  # DOCKER_PUBLISH.
-  # GitHub secrets can be configured as follows:
-  #   - DOCKER_PUBLISH = 1
-  #   - DOCKER_IMAGE = docker.io/myorg/bcc
-  #   - DOCKER_USERNAME = username
-  #   - DOCKER_PASSWORD = password
-  publish:
-    name: Publish
-    runs-on: ubuntu-latest
-    steps:
-
-    - uses: actions/checkout@v1
-
-    - name: Initialize workflow variables
-      id: vars
-      shell: bash
-      run: |
-          echo ::set-output name=DOCKER_PUBLISH::${DOCKER_PUBLISH}
-      env:
-        DOCKER_PUBLISH: "${{ secrets.DOCKER_PUBLISH }}"
-
-    - name: Build container image and publish to registry
-      id: publish-registry
-      uses: elgohr/Publish-Docker-Github-Action@2.8
-      if: ${{ steps.vars.outputs.DOCKER_PUBLISH }}
-      with:
-        name: ${{ secrets.DOCKER_IMAGE }}
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        workdir: .
-        dockerfile: Dockerfile.ubuntu
-        snapshot: true
-        cache: ${{ github.event_name != 'schedule' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,99 @@
+name: Publish Build Artifacts
+
+on: push
+
+jobs:
+  publish_images:
+    # Optionally publish container images, guarded by the GitHub secret
+    # QUAY_PUBLISH.
+    # GitHub secrets can be configured as follows:
+    #   - QUAY_PUBLISH = 1
+    #   - QUAY_TOKEN = <token from quay.io>
+    name: Publish to quay.io
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env:
+        - NAME: xenial-release
+          OS_RELEASE: 16.04
+        - NAME: bionic-release
+          OS_RELEASE: 18.04
+        - NAME: focal-release
+          OS_RELEASE: 20.04
+    steps:
+
+    - uses: actions/checkout@v1
+
+    - name: Initialize workflow variables
+      id: vars
+      shell: bash
+      run: |
+          if [ -n "${QUAY_TOKEN}" ];then
+            echo "Quay token is set, will push an image"
+            echo ::set-output name=QUAY_PUBLISH::true
+          else
+            echo "Quay token not set, skipping"
+          fi
+
+      env:
+        QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+
+    - name: Authenticate with quay.io docker registry
+      if: >
+        steps.vars.outputs.QUAY_PUBLISH
+      env:
+        QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+      run: ./scripts/docker/auth.sh ${{ github.repository }}
+
+    - name: Package docker image and push to quay.io
+      if: >
+        steps.vars.outputs.QUAY_PUBLISH
+      run: >
+        ./scripts/docker/push.sh
+        ${{ github.repository }}
+        ${{ github.ref }}
+        ${{ github.sha }}
+        ${{ matrix.env['NAME'] }}
+        ${{ matrix.env['OS_RELEASE'] }}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: ${{ matrix.env['NAME'] }}
+        path: output
+
+  # Optionally publish container images, guarded by setting the GitHub secrets
+  # GitHub secrets can be configured as follows:
+  #   - DOCKER_IMAGE = docker.io/myorg/bcc
+  #   - DOCKER_USERNAME = username
+  #   - DOCKER_PASSWORD = password
+  publish_dockerhub:
+    name: Publish To Dockerhub
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v1
+
+    - name: Initialize workflow variables
+      id: vars
+      shell: bash
+      run: |
+          if [ -n "${DOCKER_IMAGE}" ] && \
+             [ -n "${DOCKER_USERNAME}" ] && \
+             [ -n "${DOCKER_PASSWORD}" ];then
+            echo "Custom docker credentials set, will push an image"
+            echo ::set-output name=DOCKER_PUBLISH::true
+          else
+            echo "Custom docker credentials not, skipping"
+          fi
+
+    - name: Build container image and publish to registry
+      id: publish-registry
+      uses: elgohr/Publish-Docker-Github-Action@2.8
+      if: ${{ steps.vars.outputs.DOCKER_PUBLISH }}
+      with:
+        name: ${{ secrets.DOCKER_IMAGE }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        workdir: .
+        dockerfile: Dockerfile.ubuntu
+        snapshot: true
+        cache: ${{ github.event_name != 'schedule' }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ debian/**/*.log
 *critical.log
 obj-x86_64-linux-gnu
 examples/cgroupid/cgroupid
+
+# Output from docker builds
+scripts/docker/output/
+/output/

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,4 +1,10 @@
-FROM ubuntu:bionic as builder
+ARG OS_TAG=18.04
+FROM ubuntu:${OS_TAG} as builder
+
+ARG OS_TAG
+#ARG BUILD_TYPE=test
+ARG BUILD_TYPE=release
+ARG DEBIAN_FRONTEND=noninteractive
 
 MAINTAINER Brenden Blanco <bblanco@gmail.com>
 
@@ -10,10 +16,9 @@ COPY ./ /root/bcc
 WORKDIR /root/bcc
 
 RUN /usr/lib/pbuilder/pbuilder-satisfydepends && \
-    ./scripts/build-deb.sh
+    ./scripts/build-deb.sh ${BUILD_TYPE}
 
-
-FROM ubuntu:bionic
+FROM ubuntu:${OS_TAG}
 
 COPY --from=builder /root/bcc/*.deb /root/bcc/
 

--- a/debian/control
+++ b/debian/control
@@ -4,12 +4,12 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.5
 Build-Depends: debhelper (>= 9), cmake,
-    libllvm3.7 [!arm64] | libllvm3.8 [!arm64] | libllvm6.0,
-    llvm-3.7-dev [!arm64] | llvm-3.8-dev [!arm64] | llvm-6.0-dev,
-    libclang-3.7-dev [!arm64] | libclang-3.8-dev [!arm64] | libclang-6.0-dev,
-    clang-format | clang-format-3.7 [!arm64] | clang-format-3.8 [!arm64] | clang-format-6.0,
+    libllvm3.7 [!arm64] | libllvm3.8 [!arm64] | libllvm6.0 | libllvm8.0 | libllvm9,
+    llvm-3.7-dev [!arm64] | llvm-3.8-dev [!arm64] | llvm-6.0-dev | llvm-8.0-dev | llvm-9-dev,
+    libclang-3.7-dev [!arm64] | libclang-3.8-dev [!arm64] | libclang-6.0-dev | libclang-8.0-dev | libclang-9-dev,
+    clang-format | clang-format-3.7 [!arm64] | clang-format-3.8 [!arm64] | clang-format-6.0 | clang-format-8.0 | clang-format-9,
     libelf-dev, bison, flex, libfl-dev, libedit-dev, zlib1g-dev, git,
-    python (>= 2.7), python-netaddr, python-pyroute2, luajit,
+    python (>= 2.7), python-netaddr, python-pyroute2 | python3-pyroute2, luajit,
     libluajit-5.1-dev, arping, inetutils-ping | iputils-ping, iperf, netperf,
     ethtool, devscripts, python3, dh-python
 Homepage: https://github.com/iovisor/bcc

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# helper script to be invoked by jenkins/buildbot
+# helper script to be invoked by jenkins/buildbot or github actions
 
 # $1 [optional]: the build type - release | nightly | test
 buildtype=${1:-test}

--- a/scripts/docker/auth.sh
+++ b/scripts/docker/auth.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# For now only quay.io is supported, but this could be portable to dockerhub
+# and other image repositories.
+
+# Forks can push using this approach if they create a quay.io bot user
+# with name matching of ORGNAME+bcc_buildbot, or by setting QUAY_BOT_NAME
+
+git_repo=$1 # github.repository format: ORGNAME/REPONAME
+
+# Set this value as QUAY_TOKEN in the github repository settings "Secrets" tab
+[[ -z "${QUAY_TOKEN}" ]] && echo "QUAY_TOKEN not set" && exit 0
+
+# Set this to match the name of the bot user on quay.io
+[[ -z "${QUAY_BOT_NAME}" ]] && QUAY_BOT_NAME="bcc_buildbot"
+
+quay_user="$(dirname ${git_repo})+${QUAY_BOT_NAME}"
+echo "${QUAY_TOKEN}" | docker login -u="${quay_user}" --password-stdin quay.io

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Builds debian packages using docker wrapper
+
+function help() {
+  message=$1
+  echo "USAGE: build.sh DOCKER_REPO DOCKER_TAG OS_TAG [DISTRO]"
+  echo "hint: ${message}"
+}
+
+docker_repo=$1
+docker_tag=$2
+os_tag=$3
+distro=${4:-ubuntu}
+
+[ -z "${docker_repo}" ] && help "You must specify repo, eg: quay.io/iovisoc/bcc" && exit 1
+[ -z "${docker_tag}" ] && help "You must specify tag, eg: bionic-release-master, latest, SHA, git tag, etc " && exit 1
+[ -z "${os_tag}" ] && help "You must specify os tag, eg: 18.04, bionic, etc " && exit 1
+
+
+# The main docker image build,
+echo "Building ${distro} ${os_tag} release docker image for ${docker_repo}:${docker_tag}"
+docker build -t ${docker_repo}:${docker_tag} --build-arg OS_TAG=${os_tag} -f Dockerfile.${distro} .
+
+echo "Copying build artifacts to $(pwd)/output"
+mkdir output
+docker run -v $(pwd)/output:/output ${docker_repo}:${docker_tag} /bin/bash -c "cp /root/bcc/* /output"

--- a/scripts/docker/push.sh
+++ b/scripts/docker/push.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -e
+
+# Push docker tags to a configured docker repo, defaulting to quay.io
+# You must run login.sh before running this script.
+
+DEFAULT_DOCKER_REPO="quay.io"
+DEFAULT_RELEASE_TARGET="bionic-release" # will allow unprefixed tags
+
+# Currently only support pushing to quay.io
+DOCKER_REPO=${DEFAULT_DOCKER_REPO}
+
+git_repo=$1        # github.repository format: ORGNAME/REPONAME
+git_ref=$2         # github.ref        format: refs/REMOTE/REF
+                   #                       eg, refs/heads/BRANCH
+                   #                           refs/tags/v0.9.6-pre
+git_sha=$3         # github.sha                GIT_SHA
+type_name=$4       # build name, s/+/_/g   eg, bionic-release
+os_tag=${5:-18.04} # numeric docker tag    eg, 18.04
+
+# refname will be either a branch like "master" or "some-branch",
+# or a tag, like "v1.17.0-pre".
+# When a tag is pushed, a build is done for both the branch and the tag, as
+# separate builds.
+# This is a feature specific to github actions based on the `github.ref` object
+refname=$(basename ${git_ref})
+
+# The build type needs to be sanitized into a valid tag, replacing + with _
+type_tag="$(echo ${type_name} | sed 's/+/_/g')"
+
+
+echo "Triggering image build"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+${SCRIPT_DIR}/build.sh ${DOCKER_REPO}/${git_repo} ${git_sha}-${type_tag} ${os_tag}
+
+echo "Upload image for git sha ${git_sha} to ${DOCKER_REPO}/${git_repo}"
+docker push ${DOCKER_REPO}/${git_repo}:${git_sha}-${type_tag}
+
+echo "Push tags to branch or git tag HEAD refs"
+docker tag ${DOCKER_REPO}/${git_repo}:${git_sha}-${type_tag} ${DOCKER_REPO}/${git_repo}:${refname}-${type_tag}
+docker push ${DOCKER_REPO}/${git_repo}:${refname}-${type_tag}
+
+# Only push to un-suffixed tags for the default release target build type
+if [[ "${type_name}" == "${DEFAULT_RELEASE_TARGET}"* ]];then
+
+  # Update branch / git tag ref
+  echo "Pushing tags for ${DOCKER_REPO}/${git_repo}:${refname}"
+  docker tag ${DOCKER_REPO}/${git_repo}:${git_sha}-${type_tag} ${DOCKER_REPO}/${git_repo}:${refname}
+  docker push ${DOCKER_REPO}/${git_repo}:${refname}
+
+  if [[ "${refname}" == "master" ]];then
+    if [[ "${edge}" == "ON" ]];then
+      echo "This is an edge build on master, pushing ${DOCKER_REPO}/${git_repo}:edge"
+      docker tag ${DOCKER_REPO}/${git_repo}:${git_sha}-${type_tag} ${DOCKER_REPO}/${git_repo}:edge
+      docker push ${DOCKER_REPO}/${git_repo}:edge
+    else
+      echo "This is a build on master, pushing ${DOCKER_REPO}/${git_repo}:latest :SHA as well"
+      docker tag ${DOCKER_REPO}/${git_repo}:${git_sha}-${type_tag} ${DOCKER_REPO}/${git_repo}:latest
+      docker tag ${DOCKER_REPO}/${git_repo}:${git_sha}-${type_tag} ${DOCKER_REPO}/${git_repo}:${git_sha}
+      docker push ${DOCKER_REPO}/${git_repo}:latest
+      docker push ${DOCKER_REPO}/${git_repo}:${git_sha}
+    fi
+  fi
+fi

--- a/scripts/git-tag.sh
+++ b/scripts/git-tag.sh
@@ -1,4 +1,4 @@
-git_tag_latest=$(git describe --abbrev=0)
+git_tag_latest=$(git describe --tags --abbrev=0)
 git_rev_count=$(git rev-list $git_tag_latest.. --count)
 git_rev_count=$[$git_rev_count+1]
 git_subject=$(git log --pretty="%s" -n 1)


### PR DESCRIPTION
PERSONAL DRAFT COPY, NOT YET UP FOR REVIEW

This copies in the support added to bpftrace for packaging semi-static bpftrace images in CI, to minimize dependencies

I believe this will be very useful, for projects that need an up-to-date image pulled from CI on github actions, and make it easy to bisect revisions, using the docker repo as an artifact repository. In addition to docker images (for distribution purposes only, really), this also publishes debian packages as part of a tarball in the github actions output https://github.com/dalehamel/bcc/actions/runs/311964261

This builds on  `alban` 's approach of guarding the image build with a variable, but replaces the explicit variable by detecting if `QUAY_TOKEN` is present or absent. The generic dockerhub approach is still available, but I've augmented it slightly, and moved it to a separate github workflow. Since I have set this up on my personal repo by adding my own personal token, I can demonstrate the images that this publishes and tags: https://quay.io/repository/dalehamel/bcc?tab=tags

As an example, to test out the latest ubuntu focal (20.04) image:

```
docker run -ti quay.io/dalehamel/bcc:quay-push-focal-release bash
ls /root/bcc
ls /usr/share/bcc
```

I have set this up to build packages for all the most recent ubuntu LTS releases, but the process is generic enough that explicit builds for various LTS debian releases could be done fairly easily as well. I happened to add ubuntu focal support to the debian control file, as I think it is safe to do so for a new LTS release, and this is implicitly adding a CI check for this build.

This builds `release` artifacts using the existing debian build script, and results in a container being pushed and tagged in various ways (by branch, by commit, etc). This allows the user to fetch from quay.io